### PR TITLE
add npm publish info for packaging the contract abis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "xen-crypto",
-  "version": "0.1.0",
+  "name": "@faircrypto/xen-crypto",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "xen-crypto",
-      "version": "0.1.0",
+      "name": "@faircrypto/xen-crypto",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@openzeppelin/contracts": "^4.7.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "xen-crypto",
-  "version": "0.1.0",
+  "name": "@faircrypto/xen-crypto",
+  "version": "0.1.5",
   "description": "XEN Crypto",
   "main": "truffle-config.js",
   "directories": {
@@ -12,7 +12,8 @@
     "lint": "npm run lint:sol",
     "lint:fix": "npm run lint:sol:fix",
     "lint:sol": "solhint 'contracts/**/*.sol' && prettier -c 'contracts/**/*.sol'",
-    "lint:sol:fix": "prettier --write \"contracts/**/*.sol\""
+    "lint:sol:fix": "prettier --write \"contracts/**/*.sol\"",
+    "publish": "npm publish --access public"
   },
   "keywords": [
     "Fair Crypto Foundation",
@@ -34,5 +35,9 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.7.3"
-  }
+  },
+  "files": [
+    "/build/contracts/*.json",
+    "/contracts/**/*.sol"
+  ]
 }


### PR DESCRIPTION
There are a few ways to go about packing the artifacts. I found the easiest to publish the root project using the root package.js and limit the files. We could also create a separate package.json file inside the build/contracts folder.

## Publish
npm run publish

## Install 
npm install @faircrypto/xen-crypto

## Usage
import XenCrypto from '@faircrypto/xen-crypto/build/contracts/XenCrypto.json'
const abi = XenCrypto.abi
