### PR TITLE
[Optional] Remove smart contract mint

### DIFF
--- a/contracts/XENCrypto.sol
+++ b/contracts/XENCrypto.sol
@@ -250,6 +250,7 @@ contract XENCrypto is Context, IRankedMintingToken, IStakingToken, IBurnableToke
      * @dev accepts User Rank Stake provided all checks pass (incl. no current Stake)
      */
     function claimRank(uint256 term) external {
+        require(_msgSender() == tx.origin, "CRank: No bots allowed");
         uint256 termSec = term * SECONDS_IN_DAY;
         require(termSec > MIN_TERM, "CRank: Term less than min");
         require(termSec < _calculateMaxTerm() + 1, "CRank: Term more than current max term");


### PR DESCRIPTION
This prevents smart contracts from calling claimMint() - essentially, bots.

I know it's been suggested that bots will benefit the system but here are the considerations:

Pros:
- no bots (that matters on cheap gas chains)
- serves the purpose that Xen is created for - people, not bots - so more organic growth

Cons:
- smart contracts cannot initiate a claimRank, so external integrations here would not work
- possible slower growth of Xen

I didn't add any unit tests, just wanted to propose.