### PR TITLE
add truffle-plugin-verify support for verifying the contract on explorers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@faircrypto/xen-crypto",
-  "version": "0.1.7",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@faircrypto/xen-crypto",
-      "version": "0.1.7",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@openzeppelin/contracts": "^4.7.3",
-        "abdk-libraries-solidity": "^3.0.0"
+        "abdk-libraries-solidity": "^3.0.0",
+        "truffle-plugin-verify": "^0.5.28"
       },
       "devDependencies": {
         "@ethersproject/units": "^5.7.0",
@@ -979,6 +980,14 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.2.tgz",
@@ -1262,6 +1271,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/circular": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/circular/-/circular-1.0.5.tgz",
+      "integrity": "sha512-n4Sspha+wxUl5zeA3JYp1zFCjsLz2VfXIe2gRKNQBrIX+7iPdGcCGZOF8W8IULtllZ/aejXtySfdFFt1wy/3JQ=="
+    },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -1272,6 +1286,28 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cli-logger": {
+      "version": "0.5.40",
+      "resolved": "https://registry.npmjs.org/cli-logger/-/cli-logger-0.5.40.tgz",
+      "integrity": "sha512-piXVCa0TLm/+A7xdVEhw7t4OSrsmJaZIekWcoGrVMY1bHtLJTXgiNzgHlKT0EVHQ14sCKWorQJazU7UWgZhXOQ==",
+      "dependencies": {
+        "circular": "^1.0.5",
+        "cli-util": "~1.1.27"
+      }
+    },
+    "node_modules/cli-regexp": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-regexp/-/cli-regexp-0.1.2.tgz",
+      "integrity": "sha512-L++cAQ5g0Nu6aV56B3uaR+c7jEGSAa4WApY1ZN7XiD8niJ5jRfXE/qvMwgz3uZBG0rft4hJS75Vpz2F3mSm4Mg=="
+    },
+    "node_modules/cli-util": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/cli-util/-/cli-util-1.1.27.tgz",
+      "integrity": "sha512-Z6+zI0kIrqf9Oi+PmUm8J9AELp8bTf2vCLYseudYtdOPNJvzpNiExO95aHIm477IbPdu/8SE9Wvc/M1kJl4Anw==",
+      "dependencies": {
+        "cli-regexp": "~0.1.0"
       }
     },
     "node_modules/cli-width": {
@@ -1505,6 +1541,17 @@
       "dev": true,
       "dependencies": {
         "abstract-leveldown": "~2.6.0"
+      }
+    },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -2600,6 +2647,25 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
@@ -3966,6 +4032,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4578,11 +4653,31 @@
         "lodash.isequal": "^4.5.0"
       }
     },
+    "node_modules/truffle-plugin-verify": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/truffle-plugin-verify/-/truffle-plugin-verify-0.5.28.tgz",
+      "integrity": "sha512-wmWJsJPq9Zj/FaJVXISwnL0mOGGKLgSCbOnwXzxmuv+0iRcUuccFAianYP4Ru/QjzsD2T6pQ7TUjVGLEcCkMtg==",
+      "dependencies": {
+        "axios": "^0.26.1",
+        "cli-logger": "^0.5.40",
+        "delay": "^5.0.0",
+        "querystring": "^0.2.1",
+        "tunnel": "0.0.6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -5642,6 +5737,14 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.2.tgz",
@@ -5871,6 +5974,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "circular": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/circular/-/circular-1.0.5.tgz",
+      "integrity": "sha512-n4Sspha+wxUl5zeA3JYp1zFCjsLz2VfXIe2gRKNQBrIX+7iPdGcCGZOF8W8IULtllZ/aejXtySfdFFt1wy/3JQ=="
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -5878,6 +5986,28 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-logger": {
+      "version": "0.5.40",
+      "resolved": "https://registry.npmjs.org/cli-logger/-/cli-logger-0.5.40.tgz",
+      "integrity": "sha512-piXVCa0TLm/+A7xdVEhw7t4OSrsmJaZIekWcoGrVMY1bHtLJTXgiNzgHlKT0EVHQ14sCKWorQJazU7UWgZhXOQ==",
+      "requires": {
+        "circular": "^1.0.5",
+        "cli-util": "~1.1.27"
+      }
+    },
+    "cli-regexp": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-regexp/-/cli-regexp-0.1.2.tgz",
+      "integrity": "sha512-L++cAQ5g0Nu6aV56B3uaR+c7jEGSAa4WApY1ZN7XiD8niJ5jRfXE/qvMwgz3uZBG0rft4hJS75Vpz2F3mSm4Mg=="
+    },
+    "cli-util": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/cli-util/-/cli-util-1.1.27.tgz",
+      "integrity": "sha512-Z6+zI0kIrqf9Oi+PmUm8J9AELp8bTf2vCLYseudYtdOPNJvzpNiExO95aHIm477IbPdu/8SE9Wvc/M1kJl4Anw==",
+      "requires": {
+        "cli-regexp": "~0.1.0"
       }
     },
     "cli-width": {
@@ -6079,6 +6209,11 @@
       "requires": {
         "abstract-leveldown": "~2.6.0"
       }
+    },
+    "delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -7091,6 +7226,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -8238,6 +8378,11 @@
       "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8722,11 +8867,28 @@
         "lodash.isequal": "^4.5.0"
       }
     },
+    "truffle-plugin-verify": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/truffle-plugin-verify/-/truffle-plugin-verify-0.5.28.tgz",
+      "integrity": "sha512-wmWJsJPq9Zj/FaJVXISwnL0mOGGKLgSCbOnwXzxmuv+0iRcUuccFAianYP4Ru/QjzsD2T6pQ7TUjVGLEcCkMtg==",
+      "requires": {
+        "axios": "^0.26.1",
+        "cli-logger": "^0.5.40",
+        "delay": "^5.0.0",
+        "querystring": "^0.2.1",
+        "tunnel": "0.0.6"
+      }
+    },
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.7.3",
-    "abdk-libraries-solidity": "^3.0.0"
+    "abdk-libraries-solidity": "^3.0.0",
+    "truffle-plugin-verify": "^0.5.28"
   },
   "files": [
     "/build/contracts/*.json",

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "prettier": "^2.7.1",
     "prettier-plugin-solidity": "^1.0.0-beta.24",
     "solhint": "^3.3.7",
-    "truffle-assertions": "^0.9.2"
+    "truffle-assertions": "^0.9.2",
+    "truffle-plugin-verify": "^0.5.28"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.7.3",
-    "abdk-libraries-solidity": "^3.0.0",
-    "truffle-plugin-verify": "^0.5.28"
+    "abdk-libraries-solidity": "^3.0.0"
   },
   "files": [
     "/build/contracts/*.json",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -6,6 +6,9 @@ const infuraKey = process.env.INFURA_KEY || ''
 const infuraSecret = process.env.INFURA_SECRET || ''
 const liveNetworkPK = process.env.LIVE_PK || ''
 const privKeysRinkeby = [ liveNetworkPK ]
+const etherscanApiKey = process.env.ETHERS_SCAN_API_KEY || ''
+const polygonApiKey = process.env.POLYGON_SCAN_API_KEY || ''
+const bscApiKey = process.env.BSC_SCAN_API_KEY || ''
 
 module.exports = {
   networks: {
@@ -115,5 +118,11 @@ module.exports = {
   },
   db: {
     enabled: false
+  },
+  plugins: ['truffle-plugin-verify'],
+  api_keys: {
+    etherscan: etherscanApiKey,
+    bscscan: bscApiKey,
+    polygonscan: polygonApiKey
   }
 };


### PR DESCRIPTION
Added support for verifying the smart contracts after deployment

Here's the steps:

```
# Grab a API key
https://etherscan.io/myapikey

# Add the Key to .env
echo ETHERS_SCAN_API_KEY={MY_API_KEY} > .env

# Migrate contract. Note: the build artifact needs the network deploy info
truffle migrate --network goerli

# Verify the contracts
truffle run verify XENCrypto Math --network goerli
```

Other chains supported:

```
# Polygon
# https://polygonscan.com/myapikey
# POLYGON_SCAN_API_KEY=

# BSC
# https://bscscan.com/myapikey
# BSC_SCAN_API_KEY=
```